### PR TITLE
FIX: Implemented numpy.rint in minimum image routine

### DIFF
--- a/force_gromacs/tools/distances.py
+++ b/force_gromacs/tools/distances.py
@@ -13,7 +13,7 @@ def minimum_image(d_array, pbc_box):
     Parameters
     ---------
     d_array: array_like of float
-        Array of elements in n dimenions, where the last axis
+        Array of elements in n dimensions, where the last axis
         corresponds to a vector with periodic boundary conditions
         enforced by values in pbc_box
     pbc_box: array_like of floats
@@ -22,12 +22,13 @@ def minimum_image(d_array, pbc_box):
     """
 
     assert d_array.shape[-1] == pbc_box.shape[-1]
+    assert d_array.dtype == pbc_box.dtype
 
     # Obtain minimum image distances based on rectangular
     # prism geometry
     for i, dim in enumerate(pbc_box):
-        d_array[..., i] -= dim * np.array(
-            2 * d_array[..., i] / dim, dtype=int
+        d_array[..., i] -= dim * np.rint(
+            d_array[..., i] / dim
         )
 
 

--- a/force_gromacs/tools/distances.py
+++ b/force_gromacs/tools/distances.py
@@ -22,7 +22,6 @@ def minimum_image(d_array, pbc_box):
     """
 
     assert d_array.shape[-1] == pbc_box.shape[-1]
-    assert d_array.dtype == pbc_box.dtype
 
     # Obtain minimum image distances based on rectangular
     # prism geometry

--- a/force_gromacs/tools/tests/test_distances.py
+++ b/force_gromacs/tools/tests/test_distances.py
@@ -65,12 +65,7 @@ class DistancesTestCase(TestCase):
         d_coord = np.array([[[0, 0, 0],
                              [1, 5, 1]],
                             [[-1, -5, -1],
-                             [0, 0, 0]]])
-
-        with self.assertRaises(AssertionError):
-            minimum_image(d_coord, self.cell_dim)
-
-        d_coord = d_coord.astype(float)
+                             [0, 0, 0]]], dtype=float)
 
         minimum_image(d_coord, self.cell_dim)
 

--- a/force_gromacs/tools/tests/test_distances.py
+++ b/force_gromacs/tools/tests/test_distances.py
@@ -14,13 +14,13 @@ class DistancesTestCase(TestCase):
     def setUp(self):
 
         self.mol_ref = ['1PS', '1PS', '2PS', '2PS', '1NA']
-        self.coord = np.array([[0, 0, 0],
-                               [1, 1, 1],
-                               [4, 4, 4],
-                               [5, 5, 5],
-                               [2, 0, 2]])
+        self.coord = np.array([[0., 0., 0.],
+                               [1., 1., 1.],
+                               [4., 4., 4.],
+                               [5., 5., 5.],
+                               [2., 0., 2.]])
 
-        self.cell_dim = np.array([6, 6, 6])
+        self.cell_dim = np.array([6., 6., 6.])
 
         self.d_matrix = np.asarray([[[0., 0., 0.],
                                    [-1., -1., -1.],
@@ -30,12 +30,12 @@ class DistancesTestCase(TestCase):
 
                                   [[1, 1, 1],
                                    [0., 0., 0.],
-                                   [3, 3, 3],
+                                   [-3, -3, -3],
                                    [2, 2, 2],
                                    [-1, 1, -1]],
 
                                   [[-2, -2, -2],
-                                   [-3, -3, -3],
+                                   [3, 3, 3],
                                    [0., 0., 0.],
                                    [-1, -1, -1.],
                                    [2, -2, 2]],
@@ -44,12 +44,12 @@ class DistancesTestCase(TestCase):
                                    [-2, -2, -2],
                                    [1, 1, 1],
                                    [0, 0, 0.],
-                                   [-3, -1, -3]],
+                                   [3, -1, 3]],
 
                                   [[2, 0, 2],
                                    [1, -1, 1],
                                    [-2, 2, -2.],
-                                   [3, 1, 3.],
+                                   [-3, 1, -3.],
                                    [0., 0., 0.]]])
 
         self.r2_matrix = np.array([[0, 3, 12, 3, 8],
@@ -66,6 +66,11 @@ class DistancesTestCase(TestCase):
                              [1, 5, 1]],
                             [[-1, -5, -1],
                              [0, 0, 0]]])
+
+        with self.assertRaises(AssertionError):
+            minimum_image(d_coord, self.cell_dim)
+
+        d_coord = d_coord.astype(float)
 
         minimum_image(d_coord, self.cell_dim)
 
@@ -116,7 +121,6 @@ class DistancesTestCase(TestCase):
 
         d_coord = pairwise_difference_matrix(
             self.coord, self.coord, self.cell_dim)
-
         self.assertTrue(
             np.allclose(d_coord, self.d_matrix)
         )


### PR DESCRIPTION
Original implementation of `force_gromacs.tools.distances.minimum_image` function included user made command to round an array of floats to the nearest integer that relied on floor rounding when converting between data types. This has been replaced by `numpy.rint`, which does not include this reliance, to improve robustness of code. However, by doing so we need to ensure that all arguments passed into `rint` are of the same data type.

Subsequent amendments have been made to unit tests to ensure both input arguments to `minimum_image` are of the same  data type .