### PR TITLE
File check for Fragment topology parser

### DIFF
--- a/force_gromacs/data_sources/fragment/fragment.py
+++ b/force_gromacs/data_sources/fragment/fragment.py
@@ -69,7 +69,7 @@ class Fragment(HasTraits):
             try:
                 return data[self.symbol]
             except Exception:
-                return {}
+                return
 
     def _get_atoms(self):
         if self._data:

--- a/force_gromacs/data_sources/fragment/fragment.py
+++ b/force_gromacs/data_sources/fragment/fragment.py
@@ -64,11 +64,12 @@ class Fragment(HasTraits):
 
     @cached_property
     def _get__data(self):
-        data = self._reader.read(self.topology)
-        try:
-            return data[self.symbol]
-        except KeyError:
-            return {}
+        if self.topology:
+            data = self._reader.read(self.topology)
+            try:
+                return data[self.symbol]
+            except Exception:
+                return {}
 
     def _get_atoms(self):
         if self._data:

--- a/force_gromacs/data_sources/fragment/tests/test_fragment.py
+++ b/force_gromacs/data_sources/fragment/tests/test_fragment.py
@@ -37,8 +37,15 @@ class TestFragment(TestCase):
 
     def test_get__data(self):
 
+        self.fragment.topology = ''
+        self.assertIsNone(self.fragment.atoms)
+        self.assertIsNone(self.fragment.mass)
+        self.assertIsNone(self.fragment.charge)
+        self.assertIsNone(self.fragment.get_masses())
+
         with mock.patch(self.mock_method) as mockreadtop:
             mockreadtop.return_value = self.top_lines
+            self.fragment.topology = 'test_top.itp'
             self.fragment.symbol = ''
 
         self.assertEqual("Water", self.fragment.name)


### PR DESCRIPTION
This PR includes an extra file check for the `Fragment` class topology parser in order to avoid raising unnecessary exceptions. 

Now, a `GromacsTopology` reader will not be called in the `Fragment._data` property getter unless the `topology` attribute is defined, therefore averting an inevitable `IOError`.