### PR TITLE
Refactor of GromacsPipeline

### DIFF
--- a/force_gromacs/pipeline/gromacs_pipeline.py
+++ b/force_gromacs/pipeline/gromacs_pipeline.py
@@ -8,7 +8,7 @@ from force_gromacs.core.base_gromacs_process import BaseGromacsProcess
 
 
 class GromacsPipeline(BaseGromacsProcess):
-    """ A simple pipeline for Gromacs commands, based on scikit-learn
+    """A simple pipeline for Gromacs commands, based on scikit-learn
     pipeline functionality that can sequentially apply a list of Gromacs
     commands using subprocess and retain the standard output/error."""
 
@@ -27,7 +27,7 @@ class GromacsPipeline(BaseGromacsProcess):
     #      Properties
     # --------------------
 
-    #: A dictionary representing `steps `with keys as the first element
+    #: A dictionary representing `steps` with keys as the first element
     #: and values as the second element in each tuple
     named_steps = Property(Dict, depends_on='steps[]')
 

--- a/force_gromacs/pipeline/gromacs_pipeline.py
+++ b/force_gromacs/pipeline/gromacs_pipeline.py
@@ -1,5 +1,3 @@
-from itertools import islice
-
 from traits.api import (
     List, Tuple, Unicode, on_trait_change, Dict, Property
 )
@@ -32,14 +30,23 @@ class GromacsPipeline(BaseGromacsProcess):
     named_steps = Property(Dict, depends_on='steps[]')
 
     # --------------------
+    #      Defaults
+    # --------------------
+
+    def _run_output_default(self):
+        return {name: {} for name, process in self.steps}
+
+    # --------------------
     #      Listeners
     # --------------------
 
     def _get_named_steps(self):
-        return dict(**dict(self.steps))
+        return dict(self.steps)
 
     @on_trait_change('dry_run,steps[]')
     def update_dry_run(self):
+        """Syncs the dry_run attribute for each process in steps
+        to the state of self.dry_run"""
         for name, process in self.steps:
             process.dry_run = self.dry_run
 
@@ -62,25 +69,18 @@ class GromacsPipeline(BaseGromacsProcess):
         if isinstance(ind, slice):
             raise ValueError('Pipeline does not support slicing')
         try:
-            name, command = self.steps[ind]
+            name, process = self.steps[ind]
         except TypeError:
             # Not an int, try get step by name
             return self.named_steps[ind]
-        return command
+        return process
 
-    # --------------------
-    #   Private Methods
-    # --------------------
-
-    def _iter(self):
+    def __iter__(self):
         """
-        Generate (idx, (name, command)) tuples from self.steps
+        Generate (name, process) tuples from self.steps
         """
-        stop = len(self.steps)
-        generator = enumerate(islice(self.steps, 0, stop))
-
-        for idx, (name, command) in generator:
-            yield idx, name, command
+        for name, process in self.steps:
+            yield name, process
 
     # --------------------
     #    Public Methods
@@ -100,25 +100,19 @@ class GromacsPipeline(BaseGromacsProcess):
         """
         bash_script = ''
 
-        for (step_idx,
-             name,
-             command) in self._iter():
-
-            bash_script += command.bash_script() + '\n'
+        for name, process in self:
+            bash_script += process.bash_script() + '\n'
 
         return bash_script
 
     def run(self):
         """Runs all terminal commands for steps and stores output
         from subprocess in `_run_output` """
-        self.run_output = {name: {} for name, command in self.steps}
+        self.run_output = self._run_output_default()
 
-        for (step_idx,
-             name,
-             command) in self._iter():
-
-            returncode = command.run()
+        for name, process in self:
+            returncode = process.run()
 
             self.run_output[name]['returncode'] = returncode
-            self.run_output[name]['stderr'] = command.recall_stderr()
-            self.run_output[name]['stdout'] = command.recall_stdout()
+            self.run_output[name]['stderr'] = process.recall_stderr()
+            self.run_output[name]['stdout'] = process.recall_stdout()

--- a/force_gromacs/pipeline/gromacs_pipeline.py
+++ b/force_gromacs/pipeline/gromacs_pipeline.py
@@ -12,6 +12,10 @@ class GromacsPipeline(BaseGromacsProcess):
     pipeline functionality that can sequentially apply a list of Gromacs
     commands using subprocess and retain the standard output/error."""
 
+    # --------------------
+    #  Regular Attributes
+    # --------------------
+
     #: List of tuples (name, BaseGromacsProcess) objects that are chained,
     #: in the order, in which they are chained.
     steps = List(Tuple(Unicode, BaseGromacsProcess))
@@ -19,7 +23,17 @@ class GromacsPipeline(BaseGromacsProcess):
     #: Output from the most recent Gromacs run
     run_output = Dict()
 
+    # --------------------
+    #      Properties
+    # --------------------
+
+    #: A dictionary representing `steps `with keys as the first element
+    #: and values as the second element in each tuple
     named_steps = Property(Dict, depends_on='steps[]')
+
+    # --------------------
+    #      Listeners
+    # --------------------
 
     def _get_named_steps(self):
         return dict(**dict(self.steps))
@@ -28,6 +42,10 @@ class GromacsPipeline(BaseGromacsProcess):
     def update_dry_run(self):
         for name, process in self.steps:
             process.dry_run = self.dry_run
+
+    # --------------------
+    #  Protected Methods
+    # --------------------
 
     def __len__(self):
         """
@@ -50,6 +68,10 @@ class GromacsPipeline(BaseGromacsProcess):
             return self.named_steps[ind]
         return command
 
+    # --------------------
+    #   Private Methods
+    # --------------------
+
     def _iter(self):
         """
         Generate (idx, (name, command)) tuples from self.steps
@@ -59,6 +81,10 @@ class GromacsPipeline(BaseGromacsProcess):
 
         for idx, (name, command) in generator:
             yield idx, name, command
+
+    # --------------------
+    #    Public Methods
+    # --------------------
 
     def append(self, step):
         """Appends step to `self.steps` attribute"""

--- a/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
+++ b/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
@@ -83,16 +83,16 @@ class TestGromacsPipeline(TestCase):
     def test___getitem__(self):
 
         # Allow indexing by name
-        self.assertEqual(
+        self.assertIs(
             self.pipeline[0], self.pipeline['file_tree']
         )
-        self.assertEqual(
+        self.assertIs(
             self.pipeline[1], self.pipeline['genbox']
         )
-        self.assertEqual(
+        self.assertIs(
             self.pipeline[2], self.pipeline['genion']
         )
-        self.assertEqual(
+        self.assertIs(
             self.pipeline[3], self.pipeline['top_file']
         )
 

--- a/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
+++ b/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
@@ -82,7 +82,7 @@ class TestGromacsPipeline(TestCase):
 
     def test___getitem__(self):
 
-        # Allow indexing by name
+        # Allow indexing by name, both should point to same object
         self.assertIs(
             self.pipeline[0], self.pipeline['file_tree']
         )

--- a/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
+++ b/force_gromacs/pipeline/tests/test_gromacs_pipeline.py
@@ -27,10 +27,23 @@ class TestGromacsPipeline(TestCase):
 
     def test_pipeline_getitem(self):
 
-        self.assertEqual(type(self.pipeline[0]), GromacsFileTreeBuilder)
-        self.assertEqual(type(self.pipeline[1]), Gromacs_genbox)
-        self.assertEqual(type(self.pipeline[2]), Gromacs_genion)
-        self.assertEqual(type(self.pipeline[3]), GromacsTopologyWriter)
+        self.assertIsInstance(self.pipeline[0], GromacsFileTreeBuilder)
+        self.assertIsInstance(self.pipeline[1], Gromacs_genbox)
+        self.assertIsInstance(self.pipeline[2], Gromacs_genion)
+        self.assertIsInstance(self.pipeline[3], GromacsTopologyWriter)
+
+        self.assertIsInstance(
+            self.pipeline['file_tree'], GromacsFileTreeBuilder
+        )
+        self.assertIsInstance(
+            self.pipeline['genbox'], Gromacs_genbox
+        )
+        self.assertIsInstance(
+            self.pipeline['genion'], Gromacs_genion
+        )
+        self.assertIsInstance(
+            self.pipeline['top_file'], GromacsTopologyWriter
+        )
 
         self.assertEqual(4, len(self.pipeline))
 
@@ -51,12 +64,28 @@ class TestGromacsPipeline(TestCase):
             list(self.pipeline.named_steps.keys())
         )
 
+        self.assertIsInstance(
+            self.pipeline.named_steps['file_tree'], GromacsFileTreeBuilder
+        )
+        self.assertIsInstance(
+            self.pipeline.named_steps['genbox'], Gromacs_genbox
+        )
+        self.assertIsInstance(
+            self.pipeline.named_steps['genion'], Gromacs_genion
+        )
+        self.assertIsInstance(
+            self.pipeline.named_steps['top_file'], GromacsTopologyWriter
+        )
+
         new_command = Gromacs_genbox(dry_run=True)
         self.pipeline.append(('new_command', new_command))
         self.assertEqual(
             ['file_tree', 'genbox', 'genion', 'top_file',
              'new_command'],
             list(self.pipeline.named_steps.keys())
+        )
+        self.assertIsInstance(
+            self.pipeline.named_steps['new_command'], Gromacs_genbox
         )
 
     def test___getitem__(self):

--- a/force_gromacs/tests/dummy_classes.py
+++ b/force_gromacs/tests/dummy_classes.py
@@ -1,18 +1,2 @@
 def dummy_function(*args, **kwargs):
     return
-
-
-class DummyCommand:
-    pass
-
-
-class DummyCommand_2(DummyCommand):
-
-    def bash_script(self):
-        pass
-
-
-class DummyCommand_3(DummyCommand_2):
-
-    def run(self):
-        pass


### PR DESCRIPTION
This PR refactors the `GromacsPipeline` class, in particular:

- Converts the `named_steps` property on `GromacsPipeline` into a traits `Property` class, rather than using the `@property` decorator.
- The getter method for `named_steps` is also simplified to remove redundant code
- Converts the `_iter` method into a regular python `__iter__` method, that no longer returns the index of iteration.
- Subsequent updates to `bash_script` and `run` methods to account for these changes
- Unit testing has also been refactored to reflect these changes and to remove code that was testing functionalities covered by the `traits` library.