### PR TITLE
FIX: SimulationProgressEvent Serialize Method

### DIFF
--- a/force_gromacs/data_sources/simulation/simulation_data_source.py
+++ b/force_gromacs/data_sources/simulation/simulation_data_source.py
@@ -45,9 +45,7 @@ class SimulationDataSource(BaseDataSource):
         """
 
         model.driver_event = SimulationProgressEvent(
-            bash_script=DataValue(
-                type="SCRIPT", value=bash_script
-            )
+            bash_script=bash_script
         )
 
     def create_bash_script(self, pipeline, name=None):

--- a/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
+++ b/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
@@ -161,7 +161,7 @@ class TestSimulationDataSource(TestCase, UnittestTools):
             mocksim.return_value = ProbeSimulationBuilder()
             self.data_source.run(self.model, data_values)
 
-        bash_script = self.model.driver_event.bash_script.value
+        bash_script = self.model.driver_event.bash_script
 
         commands = bash_script.split('\n')
         self.assertEqual(17, len(commands))

--- a/force_gromacs/notification_listeners/driver_events.py
+++ b/force_gromacs/notification_listeners/driver_events.py
@@ -1,4 +1,4 @@
-from traits.api import Instance, Unicode
+from traits.api import Unicode
 
 from force_bdss.api import BaseDriverEvent
 
@@ -8,4 +8,4 @@ class SimulationProgressEvent(BaseDriverEvent):
     of a bash script to be passed into a HPCWriter.
     """
     #: The bash script for a Gromacs Experiment
-    bash_script = Instance(Unicode)
+    bash_script = Unicode()

--- a/force_gromacs/notification_listeners/driver_events.py
+++ b/force_gromacs/notification_listeners/driver_events.py
@@ -1,7 +1,6 @@
-from traits.api import Instance
+from traits.api import Instance, Unicode
 
-from force_bdss.api import BaseDriverEvent, DataValue
-from force_bdss.io.workflow_writer import pop_dunder_recursive
+from force_bdss.api import BaseDriverEvent
 
 
 class SimulationProgressEvent(BaseDriverEvent):
@@ -9,9 +8,4 @@ class SimulationProgressEvent(BaseDriverEvent):
     of a bash script to be passed into a HPCWriter.
     """
     #: The bash script for a Gromacs Experiment
-    bash_script = Instance(DataValue)
-
-    def __getstate__(self):
-        d = pop_dunder_recursive(super().__getstate__())
-        d["bash_script"] = d["bash_script"].__getstate__()
-        return d
+    bash_script = Instance(Unicode)

--- a/force_gromacs/notification_listeners/hpc_writer/hpc_writer.py
+++ b/force_gromacs/notification_listeners/hpc_writer/hpc_writer.py
@@ -79,7 +79,7 @@ class HPCWriter(BaseNotificationListener):
 
         if isinstance(event, SimulationProgressEvent):
 
-            bash_script = event.bash_script.value
+            bash_script = event.bash_script
 
             simulation_name = self._extract_simulation_name(bash_script)
             file_path = self.create_file_path(simulation_name)

--- a/force_gromacs/notification_listeners/hpc_writer/tests/test_hpc_writer.py
+++ b/force_gromacs/notification_listeners/hpc_writer/tests/test_hpc_writer.py
@@ -88,9 +88,7 @@ class TestHPCWriter(TestCase, UnittestTools):
     def test_progress_event_handling(self):
 
         event = SimulationProgressEvent(
-            bash_script=DataValue(
-                type='SCRIPT', value=self.script
-            )
+            bash_script=self.script
         )
 
         self.assertEqual(
@@ -98,12 +96,9 @@ class TestHPCWriter(TestCase, UnittestTools):
             self.notification_listener.deliver(event)
         )
         self.assertEqual(
-            {'bash_script':
-                {'accuracy': None,
-                 'name': '',
-                 'quality': 'AVERAGE',
-                 'type': 'SCRIPT',
-                 'value': '# experiment_5.0\nmdrun -s test_topol.tpr\n'}
-             },
+            {
+                'bash_script':
+                    '# experiment_5.0\nmdrun -s test_topol.tpr\n'
+            },
             event.__getstate__()
         )

--- a/force_gromacs/notification_listeners/hpc_writer/tests/test_hpc_writer.py
+++ b/force_gromacs/notification_listeners/hpc_writer/tests/test_hpc_writer.py
@@ -2,8 +2,6 @@ from unittest import TestCase, mock
 
 from traits.testing.unittest_tools import UnittestTools
 
-from force_bdss.api import DataValue
-
 from force_gromacs.gromacs_plugin import GromacsPlugin
 from force_gromacs.notification_listeners.driver_events import (
     SimulationProgressEvent


### PR DESCRIPTION
The `SimulationProgressEvent` class has a `bash_script` attribute of type `DataValue`. The serialization and deserialization of this non-basic python type is not currently supported by the ZMQ server being used in `force-wfmanager`. Therefore we revert to simply passing a unicode string, instead of an instance of `DataValue`.

Any additional information contained in the `DataValue` class may be included at a later date, once the ZMQ server serialization and deserialization methods have been updated to include more complex data types.