### PR TITLE
ENH: Use EDM Gromacs 2019 Egg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ source = force_gromacs
 omit = */tests/*
        */bench/*
        */scripts/*
+       api.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,9 +4,9 @@ source = force_gromacs
 omit = */tests/*
        */bench/*
        */scripts/*
-       api.py
 
 [report]
+omit = force_gromacs/api.py
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 
 env:
   global:
-    - EDM_FULL=1.11.0
-      EDM_X_Y=1.11
+    - EDM_FULL=2.1.0
+      EDM_X_Y=2.1
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,18 @@ matrix:
       - xvfb
     env:
       - EDM_OS="rh6_x86_64"
+      - EDM_INSTALLER_PREFIX="edm_cli"
         EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
   - os: osx
     env:
       - EDM_OS="osx_x86_64"
+      - EDM_INSTALLER_PREFIX="edm"
         EDM_INSTALLER_SUFFIX=".pkg"
 
 before_install:
-    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
-    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
       - xvfb
     env:
       - EDM_OS="rh6_x86_64"
-      - EDM_INSTALLER_PREFIX="edm_cli"
+      - EDM_INSTALLER_PREFIX="edm_cli_"
         EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
   - os: osx
     env:
       - EDM_OS="osx_x86_64"
-      - EDM_INSTALLER_PREFIX="edm"
+      - EDM_INSTALLER_PREFIX="edm_"
         EDM_INSTALLER_SUFFIX=".pkg"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     services:
       - xvfb
     env:
-      - EDM_OS="rh5_x86_64"
+      - EDM_OS="rh6_x86_64"
         EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
   - os: osx
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ matrix:
         EDM_INSTALLER_SUFFIX=".pkg"
 
 before_install:
-    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
-    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
+    - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./${EDM_INSTALLER} -target / ; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -38,8 +38,9 @@ def install(python_version):
         "--yes"] + ADDITIONAL_CORE_DEPS)
     if returncode:
         raise click.ClickException("Error while installing EDM dependencies."
-                                   "Make sure you are using a EDM >= 2.1, otherwise"
-                                   "please download the latest version available")
+                                   "Make sure you are using a EDM >= 2.1, "
+                                   "otherwise please download the latest "
+                                   "version available")
 
     for dep in ADDITIONAL_PIP_DEPS:
         returncode = edm_run(env_name, ["pip", "install", dep])

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -34,7 +34,7 @@ def install(python_version):
     env_name = get_env_name(python_version)
 
     returncode = subprocess.call([
-        "edm", "install", "-e", env_name,
+        "edm", "install", "-e", env_name, "--add-repository", "enthought/lgpl",
         "--yes"] + ADDITIONAL_CORE_DEPS)
     if returncode:
         raise click.ClickException("Error while installing EDM dependencies.")

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -37,7 +37,9 @@ def install(python_version):
         "edm", "install", "-e", env_name, "--add-repository", "enthought/lgpl",
         "--yes"] + ADDITIONAL_CORE_DEPS)
     if returncode:
-        raise click.ClickException("Error while installing EDM dependencies.")
+        raise click.ClickException("Error while installing EDM dependencies."
+                                   "Make sure you are using a EDM >= 2.1, otherwise"
+                                   "please download the latest version available")
 
     for dep in ADDITIONAL_PIP_DEPS:
         returncode = edm_run(env_name, ["pip", "install", dep])

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -6,10 +6,10 @@ import subprocess
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
-ADDITIONAL_CORE_DEPS = [
-    "numpy>=1.13.0",
-    "gromacs==2019.4-1"
-]
+ADDITIONAL_CORE_DEPS = {
+    'free': ["numpy>=1.13.0"],
+    'lgpl': ["gromacs==2019.4-1"]
+}
 
 ADDITIONAL_PIP_DEPS = [
 ]
@@ -33,14 +33,15 @@ python_version_option = click.option(
 def install(python_version):
     env_name = get_env_name(python_version)
 
-    returncode = subprocess.call([
-        "edm", "install", "-e", env_name, "--add-repository", "enthought/lgpl",
-        "--yes"] + ADDITIONAL_CORE_DEPS)
-    if returncode:
-        raise click.ClickException("Error while installing EDM dependencies."
-                                   "Make sure you are using a EDM >= 2.1, "
-                                   "otherwise please download the latest "
-                                   "version available")
+    for key, value in ADDITIONAL_CORE_DEPS.items():
+        returncode = subprocess.call([
+            "edm", "install", "-e", env_name, "--add-repository", f"enthought/{key}",
+            "--yes"] + value)
+        if returncode:
+            raise click.ClickException("Error while installing EDM dependencies."
+                                       "Make sure you are using a EDM >= 2.1, "
+                                       "otherwise please download the latest "
+                                       "version available")
 
     for dep in ADDITIONAL_PIP_DEPS:
         returncode = edm_run(env_name, ["pip", "install", dep])

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -7,7 +7,8 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    "numpy>=1.13.0"
+    "numpy>=1.13.0",
+    "gromacs==2019.4-1"
 ]
 
 ADDITIONAL_PIP_DEPS = [

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -35,13 +35,13 @@ def install(python_version):
 
     for key, value in ADDITIONAL_CORE_DEPS.items():
         returncode = subprocess.call([
-            "edm", "install", "-e", env_name, "--add-repository", f"enthought/{key}",
-            "--yes"] + value)
+            "edm", "install", "-e", env_name, "--add-repository",
+            f"enthought/{key}", "--yes"] + value)
         if returncode:
-            raise click.ClickException("Error while installing EDM dependencies."
-                                       "Make sure you are using a EDM >= 2.1, "
-                                       "otherwise please download the latest "
-                                       "version available")
+            raise click.ClickException("Error while installing EDM "
+                                       "dependencies. Make sure you are using"
+                                       " EDM >= 2.1, otherwise please download"
+                                       " the latest version available")
 
     for dep in ADDITIONAL_PIP_DEPS:
         returncode = edm_run(env_name, ["pip", "install", dep])

--- a/force_gromacs/api.py
+++ b/force_gromacs/api.py
@@ -2,6 +2,8 @@ from .commands.gromacs_commands import Gromacs_mdrun # noqa
 from .commands.gromacs_commands import Gromacs_genconf # noqa
 from .commands.gromacs_commands import Gromacs_grompp # noqa
 from .commands.gromacs_commands import Gromacs_genbox # noqa
+from .commands.gromacs_commands import Gromacs_solvate # noqa
+from .commands.gromacs_commands import Gromacs_insert_molecules # noqa
 from .commands.gromacs_commands import Gromacs_genion # noqa
 from .commands.gromacs_commands import Gromacs_trjconv # noqa
 from .commands.gromacs_commands import Gromacs_select # noqa

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -162,7 +162,7 @@ class Gromacs_select(BaseGromacsCommand):
                       '-e', '-dt', 'tu', '-fgroup', '-xvg',
                       '-rmpbc', '-normpbc', '-pbc', '-nppbc', '-sf',
                       '-selrpos', '-seltype', '-select', '-norm',
-                      '-nonorm', '-resnr', 'pdbatoms', '-cumlt',
+                      '-nonorm', '-resnr', '-pdbatoms', '-cumlt',
                       '-nocumlt'])
 
     def _get_name(self):

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -6,13 +6,15 @@ subclasses:
 * :class:`Gromacs_grompp` provides a wrapper around Gromacs genmpp command.
 * :class:`Gromacs_genion` provides a wrapper around Gromacs genion command.
 * :class:`Gromacs_mdrun` provides a wrapper around Gromacs mdrun command.
+* :class:`Gromacs_mdrun` provides a wrapper around Gromacs mdrun command.
+* :class:`Gromacs_select` provides a wrapper around Gromacs select command.
 
 The `name` and `flags` attributes of these subclasses have been overridden as
 ReadOnly traits, and so cannot be mutated during runtime. Developers wishing to
 create further wrappers around additional Gromacs commands are encouraged to do
 so in a similar way.
 
-Note - all objects are tested on Gromacs version 4.6.7
+Note - all objects have been tested on both Gromacs versions 4.6.7 and 2019.4
 """
 
 from traits.api import Unicode, ReadOnly, Property, Bool, Int

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -75,7 +75,8 @@ class Gromacs_solvate(BaseGromacsCommand):
 
 class Gromacs_insert_molecules(BaseGromacsCommand):
     """Wrapper around Gromacs insert-molecules command
-    http://manual.gromacs.org/documentation/2018/onlinehelp/gmx-insert-molecules.html"""
+    http://manual.gromacs.org/documentation/2018/onlinehelp/gmx-insert-molecules.html # noqa
+    """
 
     #: Name of Gromacs genbox command
     name = ReadOnly('insert-molecules')
@@ -161,18 +162,19 @@ class Gromacs_mdrun(BaseGromacsCommand):
         )
 
     def _get_name(self):
+        """Returns correct name syntax, depending on MPI run
+        option and installation version"""
         if self.mpi_run and not self.executable:
             return "mdrun_mpi"
         return "mdrun"
 
     def _build_command(self):
+        """Overloads build_command option to include shell mpirun
+        command with processor count if running in parallel"""
         command = super()._build_command()
-
         if self.mpi_run:
             command = f"mpirun -np {self.n_proc} {command}"
-
         return command
-
 
 
 class Gromacs_select(BaseGromacsCommand):
@@ -196,10 +198,13 @@ class Gromacs_select(BaseGromacsCommand):
         super(Gromacs_select, self).__init__(*args, **kwargs)
 
     def _get_name(self):
+        """Returns correct name syntax, depending on installation
+        version"""
         if self.executable == 'gmx':
             return 'select'
         else:
             return 'g_select'
+
 
 class Gromacs_trjconv(BaseGromacsCommand):
     """Wrapper around Gromacs trjconv command

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -32,10 +32,6 @@ class Gromacs_genconf(BaseGromacsCommand):
     #: List of accepted flags for Gromacs genbox command
     flags = ReadOnly(['-f', '-o', '-trj', '-nbox'])
 
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_genconf, self).__init__(*args, **kwargs)
-
 
 #: NOTE: as of Gromacs 5.0, this tool has been split to gmx solvate
 #: and gmx insert-molecules.
@@ -53,10 +49,6 @@ class Gromacs_genbox(BaseGromacsCommand):
     flags = ReadOnly(['-cp', '-cs', '-ci', '-maxsol',
                       '-o', '-box', '-try', '-nmol'])
 
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_genbox, self).__init__(*args, **kwargs)
-
 
 class Gromacs_solvate(BaseGromacsCommand):
     """Wrapper around Gromacs solvate command
@@ -69,10 +61,6 @@ class Gromacs_solvate(BaseGromacsCommand):
     flags = ReadOnly(['-cp', '-cs', '-p', '-maxsol',
                       '-o', '-box', '-radius', '-scale',
                       '-shell', '-vel'])
-
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_solvate, self).__init__(*args, **kwargs)
 
 
 class Gromacs_insert_molecules(BaseGromacsCommand):
@@ -89,10 +77,6 @@ class Gromacs_insert_molecules(BaseGromacsCommand):
                       '-box', '-nmol', '-try', '-seed',
                       '-radius', '-scale', '-dr', '-rot'])
 
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_insert_molecules, self).__init__(*args, **kwargs)
-
 
 class Gromacs_grompp(BaseGromacsCommand):
     """Wrapper around Gromacs grompp command
@@ -106,10 +90,6 @@ class Gromacs_grompp(BaseGromacsCommand):
                       '-t', '-e', '-ref', '-po', '-pp',
                       '-o', '-idm', '-time', '-maxwarn'])
 
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_grompp, self).__init__(*args, **kwargs)
-
 
 class Gromacs_genion(BaseGromacsCommand):
     """Wrapper around Gromacs genion command
@@ -122,10 +102,6 @@ class Gromacs_genion(BaseGromacsCommand):
     flags = ReadOnly(['-s', '-n', '-p', '-o', '-np', '-pname',
                       '-pq', '-nn', '-nname', '-nq', '-rmin',
                       '-seed', '-conc'])
-
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_genion, self).__init__(*args, **kwargs)
 
 
 class Gromacs_mdrun(BaseGromacsCommand):
@@ -156,12 +132,6 @@ class Gromacs_mdrun(BaseGromacsCommand):
     #: List of accepted flags for Gromacs mdrun command
     flags = ReadOnly(['-s', '-g', '-e', '-o', '-x', '-c',
                       '-cpo'])
-
-    def __init__(self, flags=None, *args, **kwargs):
-
-        super(Gromacs_mdrun, self).__init__(
-            *args, **kwargs
-        )
 
     def _get_name(self):
         """Returns correct name syntax, depending on MPI run
@@ -195,10 +165,6 @@ class Gromacs_select(BaseGromacsCommand):
                       '-nonorm', '-resnr', 'pdbatoms', '-cumlt',
                       '-nocumlt'])
 
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_select, self).__init__(*args, **kwargs)
-
     def _get_name(self):
         """Returns correct name syntax, depending on installation
         version"""
@@ -225,7 +191,3 @@ class Gromacs_trjconv(BaseGromacsCommand):
                       '-trunc', '-exec', '-split', '-sep', '-nosep',
                       '-nzero', '-dropunder', '-dropover', '-conect',
                       '-noconect'])
-
-    def __init__(self, name=None, flags=None,
-                 *args, **kwargs):
-        super(Gromacs_trjconv, self).__init__(*args, **kwargs)

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -151,7 +151,7 @@ class Gromacs_mdrun(BaseGromacsCommand):
 
 class Gromacs_select(BaseGromacsCommand):
     """Wrapper around Gromacs select (or g_select) command
-    http://manual.gromacs.org/archive/4.6.5/online/g_select.html"""
+    http://manual.gromacs.org/documentation/2019/onlinehelp/gmx-select.html"""
 
     #: Name of Gromacs select command
     name = Property(Unicode, depends_on='executable')
@@ -176,7 +176,7 @@ class Gromacs_select(BaseGromacsCommand):
 
 class Gromacs_trjconv(BaseGromacsCommand):
     """Wrapper around Gromacs trjconv command
-    http://manual.gromacs.org/documentation/2018/onlinehelp/gmx-trjconv.html"""
+    http://manual.gromacs.org/documentation/2019/onlinehelp/gmx-trjconv.html"""
 
     #: Name of Gromacs trjconv command
     name = ReadOnly('trjconv')

--- a/force_gromacs/commands/tests/test_gromacs_commands.py
+++ b/force_gromacs/commands/tests/test_gromacs_commands.py
@@ -5,7 +5,7 @@ from traits.trait_errors import TraitError
 from force_gromacs.commands.gromacs_commands import (
     Gromacs_genbox, Gromacs_grompp, Gromacs_genion,
     Gromacs_mdrun, Gromacs_genconf, Gromacs_trjconv,
-    Gromacs_select
+    Gromacs_select, Gromacs_solvate, Gromacs_insert_molecules
 )
 
 
@@ -13,14 +13,16 @@ class TestGromacsCommands(TestCase):
 
     def setUp(self):
         #: Create Gromacs command objects
-        self.genconf = Gromacs_genconf(dry_run=True)
-        self.genbox = Gromacs_genbox(dry_run=True)
-        self.grompp = Gromacs_grompp(dry_run=True)
-        self.genion = Gromacs_genion(dry_run=True)
-        self.mdrun = Gromacs_mdrun(dry_run=True)
-        self.mdrun_mpi = Gromacs_mdrun(mpi_run=True, dry_run=True)
-        self.select = Gromacs_select(dry_run=True)
-        self.trjconv = Gromacs_trjconv(dry_run=True)
+        self.genconf = Gromacs_genconf(dry_run=False)
+        self.genbox = Gromacs_genbox(dry_run=False)
+        self.solvate = Gromacs_solvate(dry_run=False)
+        self.insert_molecules = Gromacs_insert_molecules(dry_run=False)
+        self.grompp = Gromacs_grompp(dry_run=False)
+        self.genion = Gromacs_genion(dry_run=False)
+        self.mdrun = Gromacs_mdrun(dry_run=False)
+        self.mdrun_mpi = Gromacs_mdrun(mpi_run=True, dry_run=False)
+        self.select = Gromacs_select(dry_run=False)
+        self.trjconv = Gromacs_trjconv(dry_run=False)
 
     def test_readonly(self):
         with self.assertRaises(TraitError):
@@ -44,6 +46,11 @@ class TestGromacsCommands(TestCase):
         self.assertIn(' -o test_output.gro', command)
         self.assertIn(' -nbox 30', command)
 
+        self.genconf.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.genconf.run())
+        self.assertIn('SYNOPSIS', self.genconf.recall_stdout())
+
     def test_genbox(self):
 
         input_options = {
@@ -55,12 +62,60 @@ class TestGromacsCommands(TestCase):
 
         self.genbox.command_options = input_options
         command = self.genbox.bash_script()
+        self.assertNotIn('gmx', command)
         self.assertIn('genbox', command)
         self.assertIn(' -cp test_coord.gro', command)
         self.assertIn(' -o test_output.gro', command)
         self.assertIn(' -try', command)
         self.assertIn(' -nmol 30', command)
         self.assertNotIn(' -not_a_flag 60', command)
+
+    def test_solvate(self):
+
+        input_options = {
+            '-cp': 'test_coord.gro',
+            '-p': 'test_top.top',
+            '-not_a_flag': 60,
+            '-o': 'test_output.gro',
+            '-vel': True}
+
+        self.solvate.command_options = input_options
+        command = self.solvate.bash_script()
+        self.assertIn('solvate', command)
+        self.assertIn(' -cp test_coord.gro', command)
+        self.assertIn(' -p test_top.top', command)
+        self.assertIn(' -o test_output.gro', command)
+        self.assertIn(' -vel', command)
+        self.assertNotIn(' -not_a_flag 60', command)
+
+        self.genconf.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.genconf.run())
+        self.assertIn('SYNOPSIS', self.genconf.recall_stdout())
+
+    def test_insert_molecules(self):
+
+        input_options = {
+            '-cp': 'test_coord.gro',
+            '-nmol': 30,
+            '-not_a_flag': 60,
+            '-o': 'test_output.gro',
+            '-try': True}
+
+        self.insert_molecules.command_options = input_options
+        command = self.insert_molecules.bash_script()
+        self.assertIn('insert-molecules', command)
+        self.assertNotIn(' -cp test_coord.gro', command)
+        self.assertIn(' -o test_output.gro', command)
+        self.assertIn(' -try', command)
+        self.assertIn(' -nmol 30', command)
+        self.assertNotIn(' -not_a_flag 60', command)
+
+        self.insert_molecules.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.insert_molecules.run())
+        self.assertIn('SYNOPSIS',
+                      self.insert_molecules.recall_stdout())
 
     def test_grompp(self):
 
@@ -80,6 +135,12 @@ class TestGromacsCommands(TestCase):
         self.assertIn(' -p test_top.top', command)
         self.assertIn(' -maxwarn 4', command)
         self.assertNotIn(' ci nonsense', command)
+
+        self.grompp.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.grompp.run())
+        self.assertIn('SYNOPSIS',
+                      self.grompp.recall_stdout())
 
     def test_genion(self):
 
@@ -102,9 +163,15 @@ class TestGromacsCommands(TestCase):
         self.assertIn(' -pq 1', command)
         self.assertNotIn(' -cp problem', command)
 
+        self.genion.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.genion.run())
+        self.assertIn('SYNOPSIS',
+                      self.genion.recall_stdout())
+
         self.genion.user_input = 'W'
         command = self.genion.bash_script()
-        self.assertIn("echo 'W' | genion", command)
+        self.assertIn("echo 'W' | gmx genion", command)
 
     def test_mdrun(self):
 
@@ -126,15 +193,20 @@ class TestGromacsCommands(TestCase):
         self.assertIn(' -x test_traj.xtc', command)
         self.assertIn(' -c test_coord.gro', command)
 
+        self.mdrun.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.mdrun.run())
+        self.assertIn('SYNOPSIS',
+                      self.mdrun.recall_stdout())
+
         self.mdrun_mpi.command_options = input_options
         command = self.mdrun_mpi.bash_script()
+        self.assertIn('mpirun -np 1', command)
+        self.assertIn('mdrun', command)
+
+        self.mdrun_mpi.executable = ''
+        command = self.mdrun_mpi.bash_script()
         self.assertIn('mdrun_mpi', command)
-        self.assertIn(' -s test_top.trp ', command)
-        self.assertIn(' -o test_traj.trr', command)
-        self.assertIn(' -g test_md.log', command)
-        self.assertIn(' -e test_ener.edr', command)
-        self.assertIn(' -x test_traj.xtc', command)
-        self.assertIn(' -c test_coord.gro', command)
 
     def test_trjconv(self):
         command_options = {
@@ -150,6 +222,12 @@ class TestGromacsCommands(TestCase):
         self.assertIn(' -s test_coord.gro', command)
         self.assertIn(' -pbc nojump', command)
 
+        self.trjconv.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.trjconv.run())
+        self.assertIn('SYNOPSIS',
+                      self.trjconv.recall_stdout())
+
     def test_select(self):
 
         command_options = {
@@ -160,7 +238,17 @@ class TestGromacsCommands(TestCase):
 
         self.select.command_options = command_options
         command = self.select.bash_script()
-        self.assertIn('g_select', command)
+        self.assertIn('select', command)
         self.assertIn(' -f test_traj.xtc ', command)
         self.assertIn(' -on test_index.ntx', command)
         self.assertIn(' -select "( resname W )"', command)
+
+        self.select.command_options = {
+            '-h': True}
+        self.assertEqual(0, self.select.run())
+        self.assertIn('SYNOPSIS',
+                      self.select.recall_stdout())
+
+        self.select.executable = ''
+        command = self.select.bash_script()
+        self.assertIn('g_select', command)

--- a/force_gromacs/core/base_gromacs_command.py
+++ b/force_gromacs/core/base_gromacs_command.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from traits.api import (
-    Unicode, Set, Dict, List, Property, on_trait_change
+    Unicode, Enum, Set, Dict, List, Property, on_trait_change
 )
 
 from .base_gromacs_process import BaseGromacsProcess
@@ -28,6 +28,9 @@ class BaseGromacsCommand(BaseGromacsProcess):
     # --------------------
 
     #: Name of Gromacs executable
+    executable = Enum('gmx', '')
+
+    #: Name of Gromacs task
     name = Unicode(allow_none=False)
 
     #: List of accepted flags for command line options
@@ -108,7 +111,7 @@ class BaseGromacsCommand(BaseGromacsProcess):
     def _build_command(self):
         """Generate terminal command from input data"""
 
-        command = f"{self.name}"
+        command = ' '.join([self.executable, self.name]).strip()
 
         for flag, arg in self.command_options.items():
             if arg is None:

--- a/force_gromacs/core/base_gromacs_command.py
+++ b/force_gromacs/core/base_gromacs_command.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 from traits.api import (
     Unicode, Enum, Set, Dict, List, Property, on_trait_change
@@ -62,7 +63,7 @@ class BaseGromacsCommand(BaseGromacsProcess):
     def _get__flags(self):
         """Private attribute `_flags` contains unique set of command
         line options that is readonly."""
-        return set(self.flags)
+        return set(self.flags + ['-h'])
 
     @on_trait_change('command_options')
     def check_command_options(self):
@@ -81,6 +82,7 @@ class BaseGromacsCommand(BaseGromacsProcess):
     def _build_process(self, command):
         """Creates process to run Gromacs command on. Also sets up piping
         in of any arguments in `user_input` if required."""
+
         if self.user_input != '':
 
             input_proc = subprocess.Popen(
@@ -90,6 +92,7 @@ class BaseGromacsCommand(BaseGromacsProcess):
 
             process = subprocess.Popen(
                 command.split(),
+                env=os.environ,
                 stdin=input_proc.stdout,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE
@@ -101,6 +104,7 @@ class BaseGromacsCommand(BaseGromacsProcess):
         else:
             process = subprocess.Popen(
                 command.split(),
+                env=os.environ,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE

--- a/force_gromacs/core/tests/test_base_gromacs_command.py
+++ b/force_gromacs/core/tests/test_base_gromacs_command.py
@@ -12,21 +12,29 @@ class TestBaseGromacsCommand(TestCase):
     def setUp(self):
         # Create Gromacs command objects
         self.gromacs_command = BaseGromacsCommand(
-            name='gmx',
             flags=['-c', '-o', '-flag'],
             dry_run=True)
 
     def test___init__(self):
-        self.assertEqual('gmx', self.gromacs_command.name)
+        self.assertEqual('gmx', self.gromacs_command.executable)
         self.assertListEqual(
             ['-c', '-o', '-flag'], self.gromacs_command.flags
         )
         self.assertEqual(
-            {'-c', '-o', '-flag'}, self.gromacs_command._flags)
+            {'-c', '-o', '-flag', '-h'}, self.gromacs_command._flags)
 
         self.assertTrue(self.gromacs_command.dry_run)
         self.assertEqual('', self.gromacs_command.user_input)
         self.assertEqual({}, self.gromacs_command.command_options)
+
+    def test_gromacs_installation(self):
+
+        self.gromacs_command.dry_run = False
+        self.gromacs_command.command_options = {
+            '-h': True}
+        self.assertEqual('gmx -h', self.gromacs_command.bash_script())
+        self.assertEqual(0, self.gromacs_command.run())
+        self.assertIn('SYNOPSIS', self.gromacs_command.recall_stdout())
 
     def test__flags_readonly(self):
 
@@ -117,6 +125,7 @@ class TestBaseGromacsCommand(TestCase):
         self.assertEqual('', self.gromacs_command.recall_stderr())
 
         self.gromacs_command.dry_run = False
+        self.gromacs_command.executable = ''
 
         # Test simple bash command
         self.gromacs_command.name = 'echo Hello World'
@@ -134,6 +143,7 @@ class TestBaseGromacsCommand(TestCase):
 
     def test_run_command_error(self):
         self.gromacs_command.dry_run = False
+        self.gromacs_command.executable = ''
 
         # Test unrecognised command
         self.gromacs_command.name = 'not_a_command'


### PR DESCRIPTION
This PR approaches #21 by including the `gromacs-2019.4-1` egg from EDM as a dependency. By doing so we also need to update the syntax used by each `BaseGromacsCommand` subclass to include the `gmx` executable in each generated command. Additional changes are also made to deal with Gromacs commands that were deprecated between versions 4.6.7 and 2019.4

Gromacs 2019.4 is now assumed as the default build - consequently, the PR also closes #3, #4, and #8

## Change log
- EDM core dependency `gromacs-2019.4-1` egg  included (from `enthought/lgpl`)
- Bumped Travis CI EDM version to 2.1.0 (including update to RH6 in order to support)
- `BaseGromacsCommand` class has new `executable` attribute in order to support `gmx` command syntax
- New classes `Gromacs_solvate` and `Gromacs_insert_molecules` in order to replace deprecated `genbox` command
- `Gromacs_select` refactored to incorporate new naming convention 
- `Gromacs_mdrun` refactored to incorporate new syntax for MPI runs 
