### PR TITLE
DEP: Replacing deprecated BaseDriverEvent propagation pathway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b dev/workflow-event
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b dev/workflow-event
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install

--- a/force_gromacs/data_sources/simulation/simulation_data_source.py
+++ b/force_gromacs/data_sources/simulation/simulation_data_source.py
@@ -4,8 +4,6 @@ from force_bdss.api import (
     BaseDataSource, DataValue, Slot, Instance
 )
 
-from force_gromacs.notification_listeners.driver_events import (
-    SimulationProgressEvent)
 from force_gromacs.pipeline.i_simulation_builder import (
     ISimulationBuilder)
 
@@ -26,27 +24,6 @@ class SimulationDataSource(BaseDataSource):
         if os.path.exists(results_path):
             return model.ow_data
         return True
-
-    def notify_bash_script(self, model, bash_script):
-        """Notify the construction of a bash script for a Gromacs
-        simulation. Assigns an `ExperimentProgressEvent` to the
-        `progress_event` attribute on associated
-        `SimulationDataSourceModel`. By doing so it can be picked
-        up by the `UnileverMCO` and passed onto any
-        `NotificationListeners` present.
-
-        Parameters
-        ----------
-        model: SimulationDataSourceModel
-            The BaseDataSourceModel associated with this class
-        bash_script: str
-            A string containing the constructed
-            bash script to run a Gromacs simulation.
-        """
-
-        model.driver_event = SimulationProgressEvent(
-            bash_script=bash_script
-        )
 
     def create_bash_script(self, pipeline, name=None):
         """Creates a string that can be exported as a bash script
@@ -129,7 +106,7 @@ class SimulationDataSource(BaseDataSource):
             )
 
             # Export the bash script to any HPCWriterNotificationListener
-            self.notify_bash_script(model, bash_script)
+            model.notify_bash_script(bash_script)
 
             # Run simulation locally
             pipeline.run()

--- a/force_gromacs/data_sources/simulation/simulation_model.py
+++ b/force_gromacs/data_sources/simulation/simulation_model.py
@@ -5,6 +5,9 @@ from force_bdss.api import (
     BaseDataSourceModel, BaseDriverEvent, VerifierError
 )
 
+from force_gromacs.notification_listeners.driver_events import (
+    SimulationProgressEvent)
+
 
 class SimulationDataSourceModel(BaseDataSourceModel):
     """Class that inputs all required parameters for a single
@@ -48,13 +51,6 @@ class SimulationDataSourceModel(BaseDataSourceModel):
     #: File path for Gromacs Production run parameters file
     md_prod_parameters = File(
         desc='File path for Gromacs MD Parameter file')
-
-    # --------------------
-    #  Regular Attributes
-    # --------------------
-
-    #: Propagation channel for events from the SimulationDataSource
-    driver_event = Instance(BaseDriverEvent)
 
     # --------------------
     #        View
@@ -106,3 +102,20 @@ class SimulationDataSourceModel(BaseDataSourceModel):
         errors += self._n_molecule_types_check()
 
         return errors
+
+    def notify_bash_script(self, bash_script):
+        """Notify the construction of a bash script for a Gromacs
+        simulation. Assigns an `SimulationProgressEvent` to the
+        `event` attribute. By doing so it can be picked
+        up by the `Workflow` and passed onto any
+        `NotificationListeners` present.
+
+        Parameters
+        ----------
+        bash_script: str
+            A string containing the constructed
+            bash script to run a Gromacs simulation.
+        """
+        self.event = SimulationProgressEvent(
+            bash_script=bash_script
+        )

--- a/force_gromacs/data_sources/simulation/simulation_model.py
+++ b/force_gromacs/data_sources/simulation/simulation_model.py
@@ -116,6 +116,6 @@ class SimulationDataSourceModel(BaseDataSourceModel):
             A string containing the constructed
             bash script to run a Gromacs simulation.
         """
-        self.event = SimulationProgressEvent(
-            bash_script=bash_script
+        self.notify(
+            SimulationProgressEvent(bash_script=bash_script)
         )

--- a/force_gromacs/data_sources/simulation/simulation_model.py
+++ b/force_gromacs/data_sources/simulation/simulation_model.py
@@ -1,9 +1,7 @@
 from traits.api import Unicode, Bool, Int, File
 from traitsui.api import View, Item
 
-from force_bdss.api import (
-    BaseDataSourceModel, VerifierError
-)
+from force_bdss.api import BaseDataSourceModel, VerifierError
 
 from force_gromacs.notification_listeners.driver_events import (
     SimulationProgressEvent)

--- a/force_gromacs/data_sources/simulation/simulation_model.py
+++ b/force_gromacs/data_sources/simulation/simulation_model.py
@@ -1,8 +1,8 @@
-from traits.api import Unicode, Bool, Int, File, Instance
+from traits.api import Unicode, Bool, Int, File
 from traitsui.api import View, Item
 
 from force_bdss.api import (
-    BaseDataSourceModel, BaseDriverEvent, VerifierError
+    BaseDataSourceModel, VerifierError
 )
 
 from force_gromacs.notification_listeners.driver_events import (

--- a/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
+++ b/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
@@ -59,11 +59,11 @@ class TestSimulationDataSource(TestCase, UnittestTools):
             with mock.patch('os.path.exists') as mock_exists:
                 mock_exists.return_value = True
                 with self.assertTraitChanges(
-                        self.model, 'driver_event', count=0):
+                        self.model, 'event', count=0):
                     self.data_source.run(self.model, data_values)
                 self.model.ow_data = True
                 with self.assertTraitChanges(
-                        self.model, 'driver_event', count=1):
+                        self.model, 'event', count=1):
                     res = self.data_source.run(self.model, data_values)
 
         self.assertEqual(1, len(res))
@@ -141,9 +141,9 @@ class TestSimulationDataSource(TestCase, UnittestTools):
                        'mdrun -s test_topol.tpr\n')
 
         with self.assertTraitChanges(
-                self.model, 'driver_event', count=1):
-            self.data_source.notify_bash_script(
-                self.model, bash_script
+                self.model, 'event', count=1):
+            self.model.notify_bash_script(
+                bash_script
             )
 
     def test_driver_event(self):
@@ -159,9 +159,6 @@ class TestSimulationDataSource(TestCase, UnittestTools):
                         '.simulation_data_source.SimulationDataSource'
                         '.create_simulation_builder') as mocksim:
             mocksim.return_value = ProbeSimulationBuilder()
-            self.data_source.run(self.model, data_values)
-
-        bash_script = self.model.driver_event.bash_script
-
-        commands = bash_script.split('\n')
-        self.assertEqual(17, len(commands))
+            with self.assertTraitChanges(
+                    self.model, 'event', count=1):
+                self.data_source.run(self.model, data_values)


### PR DESCRIPTION
The PR implements minor updates to account for changes introduced in https://github.com/force-h2020/force-bdss/pull/269