### PR TITLE
DEV: Bump to Version 0.2.0.dev0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 FORCE GROMACS Plugin Changelog
 ==============================
 
+Release 0.2.0
+-------------
+
 Release 0.1.0
 -------------
 
-Released:
+Released: 3 Mar 2020
 
 Release notes
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.1.0"
+VERSION = "0.2.0.dev0"
 
 
 # Read description
@@ -32,6 +32,6 @@ setup(
         },
     packages=find_packages(),
     install_requires=[
-            "force_bdss >= 0.3.0",
+            "force_bdss >= 0.4.0",
         ]
 )


### PR DESCRIPTION
This PR bumps the current plugin version to `0.2.0.dev0`

We also implement dependency of `force_bdss >= 0.4.0`