### PR TITLE
ENH: Include Simulation output directory trait in SimulationDataSource

### DIFF
--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -137,7 +137,8 @@ class Gromacs_mdrun(BaseGromacsCommand):
     #: List of accepted flags for Gromacs mdrun command
     flags = ReadOnly(['-s', '-g', '-e', '-o', '-x', '-c',
                       '-cpo', '-cpi', '-rerun', '-ei',
-                      '-awh', '-mp', '-mn', '-'])
+                      '-awh', '-mp', '-mn', '-cpnum',
+                      '-nocpnum', '-multidir',])
 
     def _get_name(self):
         """Returns correct name syntax, depending on MPI run

--- a/force_gromacs/commands/gromacs_commands.py
+++ b/force_gromacs/commands/gromacs_commands.py
@@ -138,7 +138,7 @@ class Gromacs_mdrun(BaseGromacsCommand):
     flags = ReadOnly(['-s', '-g', '-e', '-o', '-x', '-c',
                       '-cpo', '-cpi', '-rerun', '-ei',
                       '-awh', '-mp', '-mn', '-cpnum',
-                      '-nocpnum', '-multidir',])
+                      '-nocpnum', '-multidir'])
 
     def _get_name(self):
         """Returns correct name syntax, depending on MPI run

--- a/force_gromacs/data_sources/fragment/tests/test_fragment_data_source.py
+++ b/force_gromacs/data_sources/fragment/tests/test_fragment_data_source.py
@@ -90,7 +90,6 @@ class TestFragmentDataSource(TestCase):
             "The number of output slots (1 values) returned by"
             " 'Gromacs Molecular Fragment' does not match the "
             "number of user-defined names specified (0 values). "
-
             "This is either a plugin error or a file error.",
             messages
         )

--- a/force_gromacs/data_sources/fragment/tests/test_fragment_data_source.py
+++ b/force_gromacs/data_sources/fragment/tests/test_fragment_data_source.py
@@ -84,7 +84,10 @@ class TestFragmentDataSource(TestCase):
         messages = [error.local_error for error in errors]
         self.assertEqual(5, len(messages))
         self.assertIn(
-            'The number of output slots is incorrect.',
+            "The number of output slots (1 values) returned by "
+            "'Gromacs Molecular Fragment' does not match the number "
+            "of user-defined names specified (0 values). "
+            "This is either a plugin error or a file error.",
             messages
         )
         self.assertIn(
@@ -101,12 +104,8 @@ class TestFragmentDataSource(TestCase):
         errors = self.model.verify()
         messages = [error.local_error for error in errors]
         self.assertEqual(2, len(messages))
-        self.assertIn(
-            'The number of output slots is incorrect.',
-            messages
-        )
-        self.assertIn(
-            'File extension does not match required.',
+        self.assertNotIn(
+            'Gromacs file name is white space.',
             messages
         )
 
@@ -114,7 +113,7 @@ class TestFragmentDataSource(TestCase):
         errors = self.model.verify()
         messages = [error.local_error for error in errors]
         self.assertEqual(1, len(messages))
-        self.assertIn(
-            'The number of output slots is incorrect.',
+        self.assertNotIn(
+            'File extension does not match required.',
             messages
         )

--- a/force_gromacs/data_sources/molecule/tests/test_molecule_data_source.py
+++ b/force_gromacs/data_sources/molecule/tests/test_molecule_data_source.py
@@ -122,7 +122,10 @@ class TestMoleculeDataSource(TestCase):
             messages
         )
         self.assertIn(
-            'The number of output slots is incorrect.',
+            "The number of output slots (1 values) returned by "
+            "'Gromacs Molecule' does not match the number of "
+            "user-defined names specified (0 values). "
+            "This is either a plugin error or a file error.",
             messages
         )
 
@@ -131,10 +134,16 @@ class TestMoleculeDataSource(TestCase):
         messages = [error.local_error for error in errors]
         self.assertEqual(2, len(messages))
         self.assertIn(
-            'The number of input slots is incorrect.',
+            "The number of input slots (1 values) returned by "
+            "'Gromacs Molecule' does not match the number of "
+            "user-defined names specified (0 values). "
+            "This is either a plugin error or a file error.",
             messages
         )
         self.assertIn(
-            'The number of output slots is incorrect.',
+            "The number of output slots (1 values) returned by "
+            "'Gromacs Molecule' does not match the number of "
+            "user-defined names specified (0 values). "
+            "This is either a plugin error or a file error.",
             messages
         )

--- a/force_gromacs/data_sources/simulation/simulation_model.py
+++ b/force_gromacs/data_sources/simulation/simulation_model.py
@@ -1,4 +1,6 @@
-from traits.api import Unicode, Bool, Int, File
+import os
+
+from traits.api import Unicode, Bool, Int, File, Directory
 from traitsui.api import View, Item
 
 from force_bdss.api import BaseDataSourceModel, VerifierError
@@ -17,6 +19,9 @@ class SimulationDataSourceModel(BaseDataSourceModel):
 
     #: Name of simulation
     name = Unicode('simulation')
+
+    # Directory to store simulation output files
+    output_directory = Directory()
 
     #: Number of Molecules
     n_molecule_types = Int(
@@ -56,6 +61,7 @@ class SimulationDataSourceModel(BaseDataSourceModel):
 
     traits_view = View(
         Item('name'),
+        Item('output_directory'),
         Item("size"),
         Item('mpi_run'),
         Item("n_proc", visible_when='mpi_run'),
@@ -65,6 +71,14 @@ class SimulationDataSourceModel(BaseDataSourceModel):
         Item("ow_data", label='Overwrite simulation data'),
         Item("dry_run")
     )
+
+    # --------------------
+    #      Defaults
+    # --------------------
+
+    def _output_directory_default(self):
+        """Use working directory as default location for output data"""
+        return os.getcwd()
 
     # --------------------
     #   Private Methods

--- a/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
+++ b/force_gromacs/data_sources/simulation/tests/test_simulation_data_source.py
@@ -1,6 +1,7 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
 
+import os
 from unittest import TestCase, mock
 
 from traits.testing.unittest_tools import UnittestTools
@@ -75,6 +76,12 @@ class TestSimulationDataSource(TestCase, UnittestTools):
 
         self.assertEqual(1, len(res))
         self.assertEqual('/path/to/trajectory.gro', res[0].value)
+
+    def test_default_traits(self):
+        self.assertEqual(
+            os.getcwd(),
+            self.model.output_directory
+        )
 
     def test__check_perform_simulation(self):
 

--- a/force_gromacs/io/file_tree_builder.py
+++ b/force_gromacs/io/file_tree_builder.py
@@ -44,7 +44,7 @@ class FileTreeBuilder(BaseProcess):
 
         for folder in self.folders:
             directory_list.append(
-                '/'.join([self.directory, folder])
+                os.path.join(self.directory, folder)
             )
 
         return directory_list

--- a/force_gromacs/io/gromacs_topology_writer.py
+++ b/force_gromacs/io/gromacs_topology_writer.py
@@ -48,7 +48,7 @@ class GromacsTopologyWriter(HasTraits):
     def _directory_default(self):
         """If directory is not defined, use current directory
         with sim_name as default directory"""
-        return f"{os.path.curdir}/{self.sim_name}"
+        return os.path.join(os.path.curdir, self.sim_name)
 
     def _top_name_default(self):
         """If topology file name is not defined, use sim_name with

--- a/force_gromacs/io/tests/test_file_tree_builder.py
+++ b/force_gromacs/io/tests/test_file_tree_builder.py
@@ -1,6 +1,7 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
 
+import os
 from unittest import TestCase, mock
 
 from force_gromacs.io.file_tree_builder import (
@@ -48,13 +49,16 @@ class TestFileTreeBuilder(TestCase):
             'test_experiment_1', directory_list[0]
         )
         self.assertEqual(
-            'test_experiment_1/1_build', directory_list[1]
+            os.path.join('test_experiment_1', '1_build'),
+            directory_list[1]
         )
         self.assertEqual(
-            'test_experiment_1/2_minimize', directory_list[2]
+            os.path.join('test_experiment_1', '2_minimize'),
+            directory_list[2]
         )
         self.assertEqual(
-            'test_experiment_1/3_production', directory_list[3]
+            os.path.join('test_experiment_1', '3_production'),
+            directory_list[3]
         )
 
     def test_bash_script(self):
@@ -67,13 +71,16 @@ class TestFileTreeBuilder(TestCase):
             'mkdir test_experiment_1', res[0]
         )
         self.assertEqual(
-            'mkdir test_experiment_1/1_build', res[1]
+            'mkdir ' + os.path.join('test_experiment_1', '1_build'),
+            res[1]
         )
         self.assertEqual(
-            'mkdir test_experiment_1/2_minimize', res[2]
+            'mkdir ' + os.path.join('test_experiment_1', '2_minimize'),
+            res[2]
         )
         self.assertEqual(
-            'mkdir test_experiment_1/3_production', res[3]
+            'mkdir ' + os.path.join('test_experiment_1', '3_production'),
+            res[3]
         )
 
     def test_run(self):

--- a/force_gromacs/io/tests/test_gromacs_topology_writer.py
+++ b/force_gromacs/io/tests/test_gromacs_topology_writer.py
@@ -1,6 +1,7 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
 
+import os
 from unittest import TestCase, mock
 import testfixtures
 
@@ -57,11 +58,11 @@ class TestGromacsTopologyWriter(TestCase):
     def test_bash_script(self):
 
         bash_script = self.writer.bash_script()
+        file_path = os.path.join('.', 'test_experiment', 'test_top.itp')
 
         res = bash_script.split('\n')
         self.assertEqual(15, len(res))
-        self.assertEqual('cat <<EOM > ./test_experiment/test_top.itp',
-                         res[0])
+        self.assertEqual(f'cat <<EOM > {file_path}', res[0])
         self.assertEqual('#include "test_surf_1.itp"', res[1])
         self.assertEqual('#include "test_surf_2.itp"', res[2])
         self.assertEqual('#include "test_salt.itp"', res[3])

--- a/force_gromacs/io/tests/test_gromacs_topology_writer.py
+++ b/force_gromacs/io/tests/test_gromacs_topology_writer.py
@@ -58,7 +58,8 @@ class TestGromacsTopologyWriter(TestCase):
     def test_bash_script(self):
 
         bash_script = self.writer.bash_script()
-        file_path = os.path.join('.', 'test_experiment', 'test_top.itp')
+        file_path = os.path.join(
+            os.path.curdir, 'test_experiment', 'test_top.itp')
 
         res = bash_script.split('\n')
         self.assertEqual(15, len(res))

--- a/force_gromacs/pipelines/tests/test_gromacs_pipeline.py
+++ b/force_gromacs/pipelines/tests/test_gromacs_pipeline.py
@@ -1,6 +1,7 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
 
+import os
 from unittest import TestCase
 
 from force_gromacs.tests.probe_classes.pipelines import (
@@ -19,16 +20,19 @@ class TestGromacsPipeline(TestCase):
         commands = self.pipeline.bash_script().split('\n')
 
         self.assertEqual(
-            'mkdir ./test_experiment', commands[0]
+            'mkdir test_experiment', commands[0]
         )
         self.assertEqual(
-            'mkdir ./test_experiment/1_build', commands[1]
+            'mkdir ' + os.path.join('test_experiment', '1_build'),
+            commands[1]
         )
         self.assertEqual(
-            'mkdir ./test_experiment/2_minimize', commands[2]
+            'mkdir ' + os.path.join('test_experiment', '2_minimize'),
+            commands[2]
         )
         self.assertEqual(
-            'mkdir ./test_experiment/3_production', commands[3]
+            'mkdir ' + os.path.join('test_experiment', '3_production'),
+            commands[3]
         )
 
         self.assertIn('solvate', commands[4])
@@ -44,8 +48,10 @@ class TestGromacsPipeline(TestCase):
         self.assertIn(' -pname test_coord_2.gro', commands[5])
         self.assertIn(' -pq 1', commands[5])
 
-        self.assertIn('cat <<EOM > ./test_experiment/test_topology.top',
-                      commands[6])
+        self.assertIn(
+            'cat <<EOM > ' + os.path.join(
+                os.path.curdir, 'test_experiment', 'test_topology.top'),
+            commands[6])
         self.assertIn('#include "test_top.itp', commands[7])
         self.assertIn('[ system ]', commands[9])
         self.assertIn('test_experiment', commands[10])

--- a/force_gromacs/simulation_builders/base_gromacs_simulation_builder.py
+++ b/force_gromacs/simulation_builders/base_gromacs_simulation_builder.py
@@ -1,5 +1,6 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
+import os
 
 from traits.api import (
     HasTraits, Str, Int, Bool, Instance, Directory,
@@ -75,7 +76,7 @@ class BaseGromacsSimulationBuilder(HasTraits):
     # --------------------
 
     def _folder_default(self):
-        return '/'.join([self.directory, self.name])
+        return os.path.join(self.directory, self.name)
 
     def _topology_data_default(self):
         return GromacsTopologyData()

--- a/force_gromacs/simulation_builders/tests/test_base_gromacs_simulation_builder.py
+++ b/force_gromacs/simulation_builders/tests/test_base_gromacs_simulation_builder.py
@@ -1,6 +1,7 @@
 #  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 #  All rights reserved.
 
+import os
 from unittest import TestCase
 
 from force_gromacs.simulation_builders.base_gromacs_simulation_builder import (
@@ -30,7 +31,10 @@ class TestGromacsSimulationBuilder(TestCase):
 
         self.assertEqual('test_experiment', self.sim_builder.name)
         self.assertEqual(100, self.sim_builder.size)
-        self.assertEqual('.', self.sim_builder.directory)
+        self.assertEqual(os.path.curdir, self.sim_builder.directory)
+        self.assertEqual(
+            os.path.join(os.path.curdir, 'test_experiment'),
+            self.sim_builder.folder)
         self.assertEqual(
             'test_martini.itp', self.sim_builder.martini_parameters
         )

--- a/force_gromacs/tests/probe_classes/pipelines.py
+++ b/force_gromacs/tests/probe_classes/pipelines.py
@@ -58,7 +58,7 @@ class ProbeGromacsPipeline(GromacsPipeline):
             (
                 'file_tree',
                 FileTreeBuilder(
-                    directory='./test_experiment',
+                    directory='test_experiment',
                     folders=[
                         '1_build', '2_minimize', '3_production'
                     ],


### PR DESCRIPTION
Adds `SimulationDataSource.output_directory` trait to specify location of output files

Also includes some minor changes to unit tests to take into account latest changes to BDSS error handling